### PR TITLE
feat: Add fail2ban support for Fedora 39+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
-# Compatibility tested with
-Need git and ansible
+# dibbs-ecr-viewer-playbook
+
+Ansible playbook to set up a DIBBS ecr-viewer environment on Fedora Server.
+
+## Features
+
+- Install Docker and dependencies on Fedora (dnf)
+- Configure fail2ban for SSH protection (Fedora 39+)
+- Create project directories and user account
+- Setup docker-compose based ecr-viewer deployment
+
+### Fail2ban Support
+
+The playbook includes fail2ban configuration for Fedora systems:
+- Installs fail2ban via dnf on Fedora 39+
+- Configures jails for sshd with DDoS protection
+- Default settings: 5-minute findtime, 10-minute ban time
+- Customizable via templates/jails.local.j2
+
+## Compatibility
+
+Tested with:
 - Fedora Server 43
-- 
+
+## Requirements
+
+- Git
+- Ansible (tested with 2.15+)
+
+## Usage
+
+```bash
+git clone https://github.com/alismx/dibbs-ecr-viewer-playbook.git
+cd dibbs-ecr-viewer-playbook
+ansible-playbook playbook.yaml
+```
+

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -6,6 +6,10 @@
     - name: Install deps
       include_tasks: tasks/deps.yaml
 
+    - name: Configure fail2ban (Fedora)
+      include_tasks: tasks/fail2ban.yaml
+      when: ansible_facts['distribution'] == "Fedora"
+
     - name: Add project directories
       include_tasks: tasks/dirs.yaml
 

--- a/tasks/fail2ban.yaml
+++ b/tasks/fail2ban.yaml
@@ -1,0 +1,51 @@
+---
+
+# Fedora - Install and configure fail2ban
+- name: Install fail2ban packages on Fedora
+  ansible.builtin.dnf:
+    name:
+      - fail2ban
+    state: present
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 39
+
+- name: Start and enable fail2ban service on Fedora
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: started
+    enabled: true
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 39
+
+# Configuration for fail2ban jails
+- name: Create fail2ban local configuration directory
+  ansible.builtin.file:
+    path: /etc/fail2ban
+    state: directory
+    mode: '0755'
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 39
+
+- name: Configure fail2ban jails.local
+  ansible.builtin.template:
+    src: templates/jails.local.j2
+    dest: /etc/fail2ban/jails.local
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 39
+  notify: Restart fail2ban
+
+# Handlers
+- name: Restart fail2ban
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: restarted
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 39

--- a/templates/jails.local.j2
+++ b/templates/jails.local.j2
@@ -1,0 +1,46 @@
+[DEFAULT]
+# "ignoreip" lists IP addresses, CIDR blocks or network interfaces to ignore.
+# IPv6 can be specified by enclosing the address in square brackets.
+ignoreip = 127.0.0.1/8 ::1
+
+# "bantime" is the number of seconds that a host will be banned.
+bantime = 10m
+
+# "findtime" is the number of seconds during which the "maxretry" attempts
+# must occur before the host is banned.
+findtime = 5m
+
+# "maxretry" is the number of failures before a host gets banned.
+maxretry = 5
+
+# "backend" specifies the backend used to get file modifications.
+# Available options are inotify, polling and auto.
+backend = auto
+
+[sshd]
+enabled = true
+port = ssh
+filter = sshd
+logpath = /var/log/secure
+maxretry = 3
+bantime = 1h
+
+[sshd-ddos]
+enabled = true
+port = ssh
+filter = sshd-ddos
+logpath = /var/log/secure
+maxretry = 5
+
+# HTTP service protection - disable if not running web server
+[http-auth]
+enabled = false
+port = http,https
+filter = http-auth
+logpath = /var/log/apache2/error.log
+
+[wordpress]
+enabled = false
+port = http,https
+filter = wordpress
+logpath = /var/log/secure


### PR DESCRIPTION
Implement fail2ban support for Fedora systems (v39+) with:

- Install fail2ban via dnf package manager
- Configure jails.local template with sshd and sshd-ddos protection
- Default settings: 5-minute findtime, 10-minute ban time, maxretry=5
- Conditional logic for Fedora distribution >= 39

Closes issue #1