### PR TITLE
Add update.sh script for playbook updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,22 @@ curl -sSL https://github.com/alismx/dibbs-ecr-viewer-playbook/install.sh | bash
 ```
 
 The script will:
-1. Clone the repository to `/tmp/dibbs-ecr-viewer-playbook`
+1. Clone the repository to `/opt/dibbs-ecr-viewer-playbook`
 2. Run the setup wizard for interactive configuration
 3. Execute the Ansible playbook to deploy eCR Viewer
-4. Clean up temporary files after installation
+
+### Updating
+
+If you used the automated installation, run the update script from the installed location:
+
+```bash
+cd /opt/dibbs-ecr-viewer-playbook && ./update.sh
+```
+
+The update script will:
+1. Pull the latest changes from the repository
+2. Re-run the Ansible playbook to apply configuration updates
+3. Restart Docker Compose services
 
 ### Manual Installation
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # Usage: curl -sSL https://github.com/alismx/dibbs-ecr-viewer-playbook/install.sh | bash
 #
 # This script will:
-# 1. Clone the repository to /tmp/dibbs-ecr-viewer-playbook
+# 1. Clone the repository to /opt/dibbs-ecr-viewer-playbook
 # 2. Run the wizard.sh setup script interactively
 # 3. Execute the Ansible playbook
 
@@ -17,19 +17,19 @@ echo ""
 
 # Configuration
 REPO_URL="https://github.com/alismx/dibbs-ecr-viewer-playbook"
-INSTALL_DIR="/tmp/dibbs-ecr-viewer-playbook"
+INSTALL_DIR="/opt/dibbs-ecr-viewer-playbook"
 PROJECT_DIR="/home/ecr-viewer/project"
 
 # Prerequisites check
 check_prerequisites() {
     echo "Checking prerequisites..."
-    
+
     # Check if curl is available
     if ! command -v curl &> /dev/null; then
         echo "ERROR: curl is required but not installed."
         exit 1
     fi
-    
+
     # Check if git is available
     if ! command -v git &> /dev/null; then
         echo "ERROR: git is required but not installed."
@@ -76,12 +76,12 @@ check_prerequisites() {
 
 clone_repository() {
     echo "Cloning repository..."
-    
+
     # Remove existing clone if present
     rm -rf "$INSTALL_DIR"
-    
+
     git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
-    
+
     echo "Repository cloned to: $INSTALL_DIR"
     echo ""
 }
@@ -111,26 +111,10 @@ run_playbook() {
     echo ""
     
     cd "$INSTALL_DIR"
-    
+
     ansible-playbook -c local playbook.yaml
-    
-    echo ""
-    echo "========================================"
-    echo "  Installation Complete!"
-    echo "========================================"
-    echo ""
-    echo "Your eCR Viewer is now installed at: $PROJECT_DIR/docker/"
-    echo "Check the .env file for your configuration."
 }
 
-cleanup() {
-    echo ""
-    read -p "Clean up temporary installation files? (Y/n): " cleanup_confirm
-    if [ "$cleanup_confirm" != "n" ] && [ "$cleanup_confirm" != "N" ]; then
-        rm -rf "$INSTALL_DIR"
-        echo "Cleanup complete."
-    fi
-}
 
 # Main execution
 main() {
@@ -138,13 +122,14 @@ main() {
     clone_repository
     run_wizard
     run_playbook
-    cleanup
-    
+
     echo ""
-    echo "Installation finished successfully!"
-    echo "Next steps:"
-    echo "  1. Check $PROJECT_DIR/docker/dibbs-ecr-viewer.env for your configuration"
-    echo "  2. Access your eCR Viewer at http://localhost:3000/ecr-viewer"
+    echo "========================================"
+    echo "  Installation Complete!"
+    echo "========================================"
+    echo ""
+    echo "Your eCR Viewer is now installed at: $PROJECT_DIR/docker/"
+    echo "Check the .env file for your configuration."
 }
 
 main

--- a/update.sh
+++ b/update.sh
@@ -16,7 +16,7 @@ echo "========================================"
 echo ""
 
 # Configuration
-REPO_DIR="${REPO_DIR:-$(dirname "$0")}"
+REPO_DIR="${REPO_DIR:-/opt/dibbs-ecr-viewer-playbook}"
 PROJECT_DIR="/home/ecr-viewer/project/docker"
 
 # Verify we're in the correct directory


### PR DESCRIPTION
This PR updates the installation and update process for DIBBS eCR Viewer.

## Changes

### install.sh
- Changed install location from `/tmp/dibbs-ecr-viewer-playbook` to `/opt/dibbs-ecr-viewer-playbook` (more permanent, standard Linux location)
- Removed cleanup step - the repository is now kept for updates
- Added `--depth 1` for shallow clone during installation

### update.sh
A new script that automates updating an existing installation:
1. Pulls latest changes from the repository
2. Re-runs the Ansible playbook to apply configuration updates
3. Restarts Docker Compose services

Usage: `cd /opt/dibbs-ecr-viewer-playbook && ./update.sh`

### README.md
- Updated documentation for installation and updating

## Notes
- Installation directory: `/opt/dibbs-ecr-viewer-playbook`
- Configuration location: `/home/ecr-viewer/project/docker/`

Closes #21