### PR TITLE
Fix: Create empty .env files if they don't exist

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -37,8 +37,8 @@ dibbs_ecr_viewer_wizard=$DIBBS_ECR_VIEWER_DIR/docker/dibbs-ecr-viewer.wizard
 # Create project directory structure if it doesn't exist
 mkdir -p "$DIBBS_ECR_VIEWER_DIR/docker"
 
-# Create default .env file if it doesn't exist
-: >"$dibbs_ecr_viewer_env"
+# Create default .env file if it doesn't exist (don't overwrite)
+[[ ! -f "$dibbs_ecr_viewer_env" ]] && : >"$dibbs_ecr_viewer_env"
 
 clear_dot_env() {
   : >"$dibbs_ecr_viewer_wizard"


### PR DESCRIPTION
This PR fixes errors where the wizard.sh script fails because environment files don't exist yet.

## Problem
The wizard.sh script requires the .env file to exist before it can:
1. Parse existing configuration defaults (set_vars function)
2. Read current values for user confirmation (check_var function)

However, this file is created by the Ansible playbook which runs AFTER the wizard.

## Solution
- Create empty dibbs_ecr-viewer.env file only if it doesn't exist before any parsing occurs
- This allows the wizard to proceed and let users configure all settings from scratch

Closes #28