### PR TITLE
Fix: Handle missing /dev/tty gracefully

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -255,7 +255,13 @@ set_vars() {
 confirm_dot_env_var() {
   value=$1
   default=$2
-  read -rp $'  \e[3m'"$value (Current Value: $default): "$'\e[0m' choice < /dev/tty
+  # Try to read from /dev/tty first (for piped execution)
+  if [[ -e /dev/tty ]]; then
+    read -rp $'  \e[3m'"$value (Current Value: $default): "$'\e[0m' choice < /dev/tty
+  else
+    # Fallback to stdin if /dev/tty doesn't exist
+    read -rp "  ${value} (Current Value: ${default}): " choice
+  fi
   if [ -z "$choice" ]; then
     choice="$default"
   fi
@@ -270,7 +276,7 @@ confirm_update() {
   vars=$(cat "$dibbs_ecr_viewer_wizard")
   echo -e "\e[1;36m$vars\e[0m"
   echo ""
-  read -rp $'  \e[3m'"Is this information correct? (y/n): "$'\e[0m' choice < /dev/tty
+  read -rp $'  \e[3m'"Is this information correct? (y/n): "$'\e[0m' choice < /dev/tty || read -p "Is this information correct? (y/n): " choice
   if [ "$choice" != "y" ]; then
     echo "Please run the script again and provide the correct information."
     exit 1


### PR DESCRIPTION
- Check if /dev/tty exists before using it
- Fallback to stdin read if /dev/tty not available