### PR TITLE
Add when condition to CONFIG_NAME write in wizard.yaml

### DIFF
--- a/roles/dibbs_ecr_viewer/tasks/wizard.yaml
+++ b/roles/dibbs_ecr_viewer/tasks/wizard.yaml
@@ -82,6 +82,7 @@
     line: 'CONFIG_NAME="{{ dibbs_ecr_viewer_config_name }}"'
     create: true
     mode: '0644'
+  when: dibbs_ecr_viewer_config_name | length > 0
 
 # Parse eCR Viewer defaults (ORCHESTRATION_URL)
 - name: Parse eCR Viewer for default environment variables


### PR DESCRIPTION
This PR adds a safety check using `when: dibbs_ecr_viewer_config_name | length > 0` to the CONFIG_NAME lineinfile task. While CONFIG_NAME should always have a value (users must select from 15 options or quit), this prevents potential empty string writes if the set_fact somehow fails.